### PR TITLE
eth_sendBundleCrossRollup

### DIFF
--- a/flashbotsrpc.go
+++ b/flashbotsrpc.go
@@ -627,6 +627,15 @@ func (rpc *FlashbotsRPC) FlashbotsCallBundle(privKey *ecdsa.PrivateKey, param Fl
 	return res, err
 }
 
+func (rpc *FlashbotsRPC) FlashbotsSendBundleCrossRollup(privKey *ecdsa.PrivateKey, param FlashbotsSendBundleCrossRollupRequest) (res FlashbotsSendBundleCrossRollupResponse, err error) {
+	rawMsg, err := rpc.CallWithFlashbotsSignature("eth_sendBundleCrossRollup", privKey, param)
+	if err != nil {
+		return res, err
+	}
+	err = json.Unmarshal(rawMsg, &res)
+	return res, err
+}
+
 func (rpc *FlashbotsRPC) FlashbotsCallAtomic(privKey *ecdsa.PrivateKey, param FlashbotsCallAtomicParam) (res FlashbotsCallAtomicResponse, err error) {
 	rawMsg, err := rpc.CallWithFlashbotsSignature("eth_callAtomic", privKey, param)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -478,3 +478,16 @@ type FlashbotsPrivateTxPreferences struct {
 type FlashbotsCancelPrivateTransactionRequest struct {
 	TxHash string `json:"txHash"`
 }
+
+type FlashbotsSendBundleCrossRollupRequest struct {
+	Txs               map[string]string `json:"txs"`
+	BlockNumber       map[string]string `json:"blockNumber"`
+	MinTimestamp      *uint64           `json:"minTimestamp,omitempty"` // (Optional) Number, the minimum timestamp for which this bundle is valid, in seconds since the unix epoch
+	MaxTimestamp      *uint64           `json:"maxTimestamp,omitempty"` // (Optional) Number, the maximum timestamp for which this bundle is valid, in seconds since the unix epoch
+	RevertingTxHashes []string          `json:"revertingTxHashes,omitempty"`
+	ReplacementUuid   string            `json:"replacementUUID,omitempty"`
+}
+
+type FlashbotsSendBundleCrossRollupResponse struct {
+	BundleHash string `json:"bundleHash"`
+}


### PR DESCRIPTION
initial spec of eth_sendBundleCrossRollup
Request
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "eth_sendBundleCrossRollup",
  "params": [
    {
      txs,               // HashMap[String, String], This contains a mapping of signed transactions alonside their corresponding chainIds which we want to execute in an atomic bundle.
      blockNumbers,       // HashMap[String, String], This contains a mapping of chainIds alongside the corresponding hex encoded block number which this bundle will be valid on.  
      minTimestamp,      // (Optional) Number, the minimum timestamp for which this bundle is valid, in seconds since the unix epoch
      maxTimestamp,      // (Optional) Number, the maximum timestamp for which this bundle is valid, in seconds since the unix epoch
      revertingTxHashes, // (Optional) Array[String], A list of tx hashes that are allowed to revert
      replacementUuid,   // (Optional) String, UUID that can be used to cancel/replace this bundle
    }
  ]
}

```
Response
```
{
  "jsonrpc": "2.0",
  "id": "123",
  "result": {
    "bundleHash": "0x2228f5d8954ce31dc1601a8ba264dbd401bf1428388ce88238932815c5d6f23f"
  }
}

```